### PR TITLE
Fix version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This contains information on the following:
 - [Results](#results)
 
 ## Installation Instructions
-You will need Python 3.6 or newer.
+You will need Python 3.6 or Python 3.7
 
 1. `cd /path/to/SuperMarioBros-AI`
 2. Run `pip install -r requirements.txt`


### PR DESCRIPTION
gym-retro [requires ](https://retro.readthedocs.io/en/latest/getting_started.html)(and doesnt install properly unless its) python 3.5, 3.6, or 3.7. Since we require ≥3.6, the only acceptable versions are 3.6 and 3.7

This caused me sooo much headache trying to install requirements since I didn't realize 3.9 was not supported